### PR TITLE
Emacs: Local Autoload System

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -22,6 +22,7 @@
 (add-to-list 'load-path "~/.emacs.d/etc/")
 (add-to-list 'load-path "~/Emacs Lisp/")
 (add-to-list 'load-path "~/elisp/")
+(add-to-list 'load-path "~/.emacs-local/")
 
 ;; Shorthand for loading files using symbols.
 (defun l (file-or-symbol &optional noerror nomessage nosuffix must-suffix)

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -47,6 +47,7 @@ In either case, passes remaining arguments to load."
 (l 'autosave)
 (l 'completion)
 (l 'code)
+(l 'duff-local 'noerror 'nomessage)
 
 ;; Load the LilyPond Emacs mode.
 (l 'lilypond-init t)


### PR DESCRIPTION
(See #3)

This Pull Request implements a new local configuration loading system.  You can now create a `duff-local` file within any of the directories in the `load-path` and it will allow you to load stuff after everything else is loaded.

Of course, this doesn't use actual Emacs autoload features, but it does enable automatically loading a local configuration if it exists.  If it doesn't exist, warnings and errors are suppressed and all is okay.
