### PR TITLE
Add iTerm ZSH Shell Integration Autoload

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -194,3 +194,5 @@ fi
 
 # added by travis gem
 [ -f /Users/kristofer/.travis/travis.sh ] && source /Users/kristofer/.travis/travis.sh
+
+test -e "${HOME}/.iterm2_shell_integration.zsh" && source "${HOME}/.iterm2_shell_integration.zsh"


### PR DESCRIPTION
This PR resolves #13 by adding the requisite ZSH integration loading line.
