### PR TITLE
ruby-mode: Add .god extension to auto-mode-alist for ruby-mode

### DIFF
--- a/.emacs.d/lisp/code.el
+++ b/.emacs.d/lisp/code.el
@@ -57,6 +57,8 @@
             (setq ruby-indent-tabs-mode t)
             (setq ruby-use-smie nil)
 
+            (add-to-list 'auto-mode-alist '("\\.god\\'" . ruby-mode))
+
             (add-hook 'ruby-mode-hook 'robe-mode)
             (add-hook 'ruby-mode-hook 'auto-complete-mode)
             (add-hook 'ruby-mode-hook 'hooks/ruby--set-indent-line-function)


### PR DESCRIPTION
This PR resolves #19 by adding the .god extension to the auto-mode-alist and associating it with ruby-mode.
