### PR TITLE
Solarized (org-mode): Use regular monospace text (no shenanigans)

### DIFF
--- a/.emacs.d/lisp/interface.el
+++ b/.emacs.d/lisp/interface.el
@@ -5,6 +5,9 @@
 (defvar interface-theme-switcher--current-pair '())
 (defvar interface-theme-switcher--alist '())
 
+(setq solarized-use-variable-pitch nil
+      solarized-scale-org-headlines nil)
+
 (defun interface-theme-switcher--preload (alist &optional no-confirm)
   (dolist (target alist)
     (progn


### PR DESCRIPTION
This PR resolves #21 by setting a few variables prior to the possible start of the theme loading callchain.  This has the effect desired in #21.
